### PR TITLE
Stream suggestion generation and ignore missing commands

### DIFF
--- a/shai/cli.py
+++ b/shai/cli.py
@@ -3,16 +3,22 @@ from __future__ import annotations
 import argparse
 from typing import List
 
-from .config import load_settings
+from .config import load_settings, add_ignored, get_ignored
 from .ui.table import ColSpec, grid_select
 from .pm.install_ui import offer_installs_for_missing
 from .app.flow import (
-    fetch_suggestions, gather_context, build_rows, make_style_functions,
-    prepend_sorted, is_installer_command, run_and_capture, refresh_requires, rank_only
+    gather_context, build_rows, make_style_functions,
+    append_new, is_installer_command, run_and_capture, refresh_requires,
+    stream_suggestions,
 )
+from .llm.suggest import ensure_ollama_running
 
 def main(argv: List[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(prog="shai", description="Natural language → CLI suggestions via Ollama.")
+    ap = argparse.ArgumentParser(
+        prog="shai",
+        description="Natural language → CLI suggestions via Ollama.",
+        epilog="Ensure the Ollama service is running (start with 'ollama serve').",
+    )
     ap.add_argument("query", nargs="*", help="what you want to do (natural language)")
     ap.add_argument("-n","--num", type=int, help="number of suggestions")
     ap.add_argument("-e","--explain", action="store_true", help="show explanations")
@@ -22,6 +28,11 @@ def main(argv: List[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     cfg = load_settings()
+    try:
+        ensure_ollama_running()
+    except RuntimeError as e:
+        print(e)
+        return 1
     model   = args.model or cfg.model
     num     = cfg.n_suggestions if args.num is None else max(1, args.num)
     num_ctx = cfg.num_ctx if args.ctx is None else max(512, int(args.ctx))
@@ -34,12 +45,19 @@ def main(argv: List[str] | None = None) -> int:
     if not query:
         print("Example: shai -n 3 --ctx 8192 'find big .log files and summarize'"); return 1
 
-    # First batch (rank ONLY the page we got)
+    # First batch
     ctx = gather_context(cfg, previous_query=query)
-    suggestions = fetch_suggestions(model, query, num, ctx, num_ctx, spinner=True)
+    print("Generating suggestions...\n")
+    counter = {"i": 0}
+    def _stream_cb(s):
+        counter["i"] += 1
+        if show_explain:
+            print(f"{counter['i']}. {s.command}\n   {s.explanation_min}")
+        else:
+            print(f"{counter['i']}. {s.command}")
+    suggestions = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, _stream_cb, spinner=cfg.spinner)
     if not suggestions:
         print("No suggestions returned."); return 2
-    suggestions = rank_only(suggestions)
 
     while True:
         rows, misslists, new_flags = build_rows(suggestions, show_explain)
@@ -66,13 +84,14 @@ def main(argv: List[str] | None = None) -> int:
             ]
         style_cell, style_line = make_style_functions(new_flags)
 
-        # 2x2 submenu
-        def menu_for_row(i: int): return ["Execute", "Comment", "Exec → Continue", "Explain"]
+        # submenu
+        def menu_for_row(i: int):
+            return ["Execute", "Comment", "Exec → Continue", "Explain", "Variations"]
 
         action, row_idx, sub_idx = grid_select(
             rows, colspecs,
             row_menu_provider=menu_for_row,
-            submenu_cols=2,  # 2x2
+            submenu_cols=cfg.submenu_cols,
             title=" Suggestions ",
             style_fn=style_cell,
             line_style_fn=style_line,
@@ -90,12 +109,12 @@ def main(argv: List[str] | None = None) -> int:
 
         # Execute / Exec → Continue
         if action == "submenu-selected" and sub_idx in (0, 2):
+            missing = [b for b in missing if b not in (cfg.ignored_bins or [])]
             if missing:
-                # Open installer UI; if anything was installed, refresh requires and go back to menu
-                installed_any = offer_installs_for_missing(missing, cfg.pm_order, cfg.n_suggestions)
+                installed_any = offer_installs_for_missing(missing, cfg.pm_order, cfg.n_suggestions, add_ignored)
+                cfg.ignored_bins = get_ignored()
                 if installed_any:
                     refresh_requires(chosen)
-                # either way, back to suggestions table
                 continue
 
             if sub_idx == 0:
@@ -105,12 +124,20 @@ def main(argv: List[str] | None = None) -> int:
                 if is_installer_command(chosen.command):
                     refresh_requires(chosen)
                     ctx = gather_context(cfg, previous_query=query)
-                    new_page = fetch_suggestions(model, query, len(suggestions), ctx, num_ctx, spinner=True)
-                    suggestions = prepend_sorted(new_page, suggestions)
+                    new_page: list = []
+                    counter = {"i": len(suggestions)}
+                    def _cb(s):
+                        counter["i"] += 1
+                        if show_explain:
+                            print(f"{counter['i']}. {s.command}\n   {s.explanation_min}")
+                        else:
+                            print(f"{counter['i']}. {s.command}")
+                    new_page = stream_suggestions(model, query, len(suggestions), ctx, num_ctx, cfg.system_prompt, _cb, spinner=cfg.spinner)
+                    suggestions = append_new(suggestions, new_page)
                     continue
                 return rc
 
-            # Exec → Continue: stream output, then REPLACE with N brand-new suggestions
+            # Exec → Continue: stream output, then append new suggestions
             print("\x1b[1mRunning:\x1b[0m " + chosen.command + "\n")
             rc, out = run_and_capture(chosen.command)
             refresh_requires(chosen)
@@ -118,16 +145,23 @@ def main(argv: List[str] | None = None) -> int:
                 follow = input("\nWhat do you want to do next? ").strip()
             except KeyboardInterrupt:
                 follow = ""
-            ctx = gather_context(cfg,
-                                 recent_output=out,
-                                 previous_query=query,
-                                 last_executed=chosen.command,
-                                 followup=follow)
-            new_page = fetch_suggestions(model, query, len(suggestions), ctx, num_ctx, spinner=True)
-            new_page = rank_only(new_page)
-            # Replace (old ones removed), mark as NEW so they’re bolded
-            for s in new_page: setattr(s, "_is_new", True)
-            suggestions = new_page
+            ctx = gather_context(
+                cfg,
+                recent_output=out,
+                previous_query=query,
+                last_executed=chosen.command,
+                followup=follow,
+            )
+            new_page: list = []
+            counter = {"i": len(suggestions)}
+            def _cb(s):
+                counter["i"] += 1
+                if show_explain:
+                    print(f"{counter['i']}. {s.command}\n   {s.explanation_min}")
+                else:
+                    print(f"{counter['i']}. {s.command}")
+            new_page = stream_suggestions(model, query, len(suggestions), ctx, num_ctx, cfg.system_prompt, _cb, spinner=cfg.spinner)
+            suggestions = append_new(suggestions, new_page)
             continue
 
         # Explain
@@ -135,16 +169,20 @@ def main(argv: List[str] | None = None) -> int:
             print("\n\x1b[1mCommand:\x1b[0m " + chosen.command)
             print("\x1b[1mExplanation:\x1b[0m")
             if getattr(chosen, "explanation_min", ""):
-                print(chosen.explanation_min)
+                parts = [p.strip() for p in chosen.explanation_min.split(';') if p.strip()]
+                for p in parts:
+                    print(" - " + p)
+                if not parts:
+                    print(chosen.explanation_min)
             else:
                 print("\x1b[2m(no explanation provided by the model)\x1b[0m")
             print("\x1b[1mTools:\x1b[0m")
-            for b,p in (chosen.requires or {}).items():
+            for b, p in (chosen.requires or {}).items():
                 print(f"  {b:10} {'✓ '+p if p else '✗ missing'}")
             input("\x1b[2m\nPress Enter to return…\x1b[0m")
             continue
 
-        # Comment → show command & explanation, accept note, PREPEND N new items (sorted)
+        # Comment → show command & explanation, accept note, append N new items
         if action == "submenu-selected" and sub_idx == 1:
             print("\n\x1b[1mCommand:\x1b[0m " + chosen.command)
             if getattr(chosen, "explanation_min", ""):
@@ -154,12 +192,42 @@ def main(argv: List[str] | None = None) -> int:
                 note = input("\nYour comment / correction: ").strip()
             except KeyboardInterrupt:
                 note = ""
-            ctx = gather_context(cfg,
-                                 previous_query=query,
-                                 last_suggested=chosen.command,
-                                 followup=note)
-            new_page = fetch_suggestions(model, query, len(suggestions), ctx, num_ctx, spinner=True)
-            suggestions = prepend_sorted(new_page, suggestions)
+            ctx = gather_context(
+                cfg,
+                previous_query=query,
+                last_suggested=chosen.command,
+                followup=note,
+            )
+            new_page: list = []
+            counter = {"i": len(suggestions)}
+            def _cb(s):
+                counter["i"] += 1
+                if show_explain:
+                    print(f"{counter['i']}. {s.command}\n   {s.explanation_min}")
+                else:
+                    print(f"{counter['i']}. {s.command}")
+            new_page = stream_suggestions(model, query, len(suggestions), ctx, num_ctx, cfg.system_prompt, _cb, spinner=cfg.spinner)
+            suggestions = append_new(suggestions, new_page)
+            continue
+
+        # Variations: ask for new variants of selected command
+        if action == "submenu-selected" and sub_idx == 4:
+            ctx = gather_context(
+                cfg,
+                previous_query=query,
+                last_suggested=chosen.command,
+                followup="variants",
+            )
+            new_page: list = []
+            counter = {"i": len(suggestions)}
+            def _cb(s):
+                counter["i"] += 1
+                if show_explain:
+                    print(f"{counter['i']}. {s.command}\n   {s.explanation_min}")
+                else:
+                    print(f"{counter['i']}. {s.command}")
+            new_page = stream_suggestions(model, query, len(suggestions), ctx, num_ctx, cfg.system_prompt, _cb, spinner=cfg.spinner)
+            suggestions = append_new(suggestions, new_page)
             continue
 
         # fallback

--- a/shai/util/shellparse.py
+++ b/shai/util/shellparse.py
@@ -1,15 +1,25 @@
 import re, shutil
 from typing import List, Dict
 
+# Bash built-ins and shell keywords that shouldn't be treated as external commands
+BUILTINS = {
+    "cd", "source", ".", "alias", "export", "unset", "set", "exit",
+    "echo", "readonly", "type", "hash", "bg", "fg"
+}
+
 def extract_commands(cmd: str) -> List[str]:
     parts = re.split(r'[|;&]', cmd)
     cmds, seen = [], set()
     for p in parts:
         toks = p.strip().split()
-        if not toks: continue
+        if not toks:
+            continue
         first = toks[1] if toks[0] == "sudo" and len(toks) > 1 else toks[0]
+        if first in BUILTINS:
+            continue
         if first not in seen:
-            seen.add(first); cmds.append(first)
+            seen.add(first)
+            cmds.append(first)
     return cmds
 
 def which_map(binaries: List[str]) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- Stream suggestions as they are generated before the selection table
- Allow users to ignore missing commands and skip future install prompts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf2a0324832fb9b3506132192e43