### PR TITLE
Stream suggestion generation and ignore missing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,97 @@
-# shai
-Shell AI short Shai. An ollama powered command line tool to get, select, modify and execute command line suggestions from natural language, tailored to your system setup. . 
+# Shai
+
+Shai (Shell AI) is an Ollama-powered command-line assistant that turns natural
+language requests into shell commands tailored to your system. It gathers
+system context, asks follow-up questions, and helps you safely run commands or
+install missing tools.
+
+## Features
+- Streams command suggestions directly into an interactive full-screen menu
+  while they are generated.
+- Shows per-command status, optional brief explanation, and highlights newly
+  added variants.
+- Menu actions for each suggestion:
+  - **Execute** – run the command as-is.
+  - **Exec → Continue** – run, capture output, then get fresh suggestions.
+  - **Comment** – refine the suggestion with your feedback.
+  - **Explain** – clear-screen view with a step-by-step breakdown of command
+    parts.
+  - **Variations** – replace the list with alternate commands.
+  - **Back** – return to the suggestions list.
+- Commands are pre-filled for editing before execution and are appended to your
+  shell history.
+- Detects missing binaries and offers to install them using your preferred
+  package managers, skip installation, or ignore specific tools forever.
+- Warns on dangerous commands (e.g. `rm`, `dd`, `mkfs`) and requires
+  confirmation unless `-u/--unsafe` is passed.
+- Collects rich context for better suggestions: OS, shell, desktop/session,
+  `.config` subfolders, current directory path and listing (with a configurable
+  max), recent output, and custom extra commands defined in the config.
+- Stores a constant part of the system prompt in `prompt.txt` so you can tweak
+  how the model behaves.
+
+## Installation
+1. Install [Ollama](https://ollama.ai) and start the service:
+   ```bash
+   ollama serve
+   ```
+2. Clone this repository and run the CLI as a module:
+   ```bash
+   git clone <repo-url>
+   cd shai
+   python -m shai "list large log files"
+   ```
+
+## Usage
+Run with a natural language request:
+```bash
+python -m shai "find large files"
+```
+If launched with no arguments, Shai will ask **What do you want to do?** in a
+centered prompt. Use the arrow keys to select a suggestion and press Enter to
+open the action menu.
+
+Helpful flags:
+- `-n/--num N` – number of suggestions.
+- `-e/--explain` or `--no-explain` – control whether brief explanations are
+  shown.
+- `--model NAME` and `--ctx TOKENS` – override model and context window.
+- `-u/--unsafe` – skip dangerous command confirmation.
+- `-h/--help` – show all CLI options.
+
+## Configuration
+A default config is created at `~/.config/shai/config`. It uses a
+TOML‑ish syntax with sections such as:
+```toml
+[model]
+name = "qwen2.5-coder:3b"
+ctx = 8192
+
+[suggestions]
+n = 3
+explain = false
+
+[context]
+history_lines = 30
+use_stdin = true
+cwd_items_max = 40
+extras = [
+  ["Kernel", "uname -r"],
+  ["Window manager", "echo $XDG_CURRENT_DESKTOP"]
+]
+
+[pm]
+order = "pacman,apt,dnf,zypper,brew,flatpak,snap,yay,paru"
+
+[prompt]
+file = "prompt.txt"
+```
+Key options:
+- `extras` – list of `[description, command]` pairs executed once at startup.
+- `pm.order` – priority of package managers to search when binaries are missing.
+- `prompt.file` – path (relative to config dir) for the system prompt text.
+- `ignored.txt` – list of binaries to skip in future install prompts.
+
+## License
+MIT – see [LICENSE](LICENSE).
+

--- a/explain_detailed.txt
+++ b/explain_detailed.txt
@@ -1,0 +1,3 @@
+You are a Linux CLI assistant.
+Given a shell command, break it into the executable and each flag or arg.
+Return STRICT JSON: {"parts":[{"text":"ls","desc":"list directory contents"}]}

--- a/ignored.txt
+++ b/ignored.txt
@@ -1,0 +1,16 @@
+bash
+sh
+ls
+cat
+echo
+cd
+pwd
+touch
+mkdir
+grep
+find
+cp
+mv
+rm
+chmod
+chown

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,12 @@
+You are a Linux CLI assistant.
+Return STRICT JSON:
+
+{"suggestions":[
+  {"command":"...", "explanation_min":"..."},
+  {"command":"...", "explanation_min":"..."}
+]}
+
+Rules:
+- Exactly N suggestions (provided in the user's JSON).
+- Single-line commands. Prefer safe flags (--dry-run, -n) where possible.
+- Prefer tools detected in context; if uncommon tool is useful, still use it.

--- a/shai/app/flow.py
+++ b/shai/app/flow.py
@@ -153,10 +153,14 @@ def build_rows(suggestions: List[Suggestion], show_explain: bool):
     return rows, misslists, new_flags
 
 # ───── per-cell styling hooks ─────
-def make_style_functions(new_flags: List[bool]):
+def make_style_functions(new_flags: List[bool], risk_flags: List[str]):
     import curses
     def style_cell(row, col, text):
         if col == 0:  # command
+            if risk_flags[row] == "danger":
+                return curses.color_pair(4) | curses.A_BOLD
+            if risk_flags[row] == "caution":
+                return curses.color_pair(7) | curses.A_BOLD
             return curses.color_pair(2)
         if col == 1:  # status
             t = (text or "")

--- a/shai/app/flow.py
+++ b/shai/app/flow.py
@@ -78,6 +78,17 @@ def gather_context(cfg,
         "cwd_contents": cwd_contents,
     }
     ctx["package_managers"] = [pm for pm in cfg.pm_order if shutil.which(pm)]
+    if getattr(cfg, "_extra_cache", None) is None:
+        extra = {}
+        for desc, cmd in (cfg.extra_context or []):
+            try:
+                out = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                extra[desc] = out.stdout.strip()
+            except Exception as e:
+                extra[desc] = f"error: {e}"
+        cfg._extra_cache = extra
+    if getattr(cfg, "_extra_cache", {}):
+        ctx["extra_context"] = cfg._extra_cache
     return ctx
 
 def is_installer_command(cmd: str) -> bool:

--- a/shai/app/flow.py
+++ b/shai/app/flow.py
@@ -124,8 +124,6 @@ def make_style_functions(new_flags: List[bool]):
     import curses
     def style_cell(row, col, text):
         if col == 0:  # command
-            if 0 <= row < len(new_flags) and new_flags[row]:
-                return curses.color_pair(6) | curses.A_BOLD
             return curses.color_pair(2)
         if col == 1:  # status
             t = (text or "")

--- a/shai/app/flow.py
+++ b/shai/app/flow.py
@@ -47,6 +47,12 @@ def gather_context(cfg,
         "shell": os.environ.get("SHELL"),
         "editor": os.environ.get("VISUAL") or os.environ.get("EDITOR"),
         "pm_order": cfg.pm_order,
+        "desktop": os.environ.get("XDG_CURRENT_DESKTOP") or os.environ.get("DESKTOP_SESSION"),
+        "session_type": os.environ.get("XDG_SESSION_TYPE"),
+        "display_server": (
+            "wayland" if os.environ.get("WAYLAND_DISPLAY") else
+            ("x11" if os.environ.get("DISPLAY") else "")
+        ),
         "stdin": _stdin_capture(cfg.use_stdin),
         "num_ctx": cfg.num_ctx,
         "previous_query": previous_query,

--- a/shai/app/flow.py
+++ b/shai/app/flow.py
@@ -1,7 +1,7 @@
 # shai/app/flow.py
 from __future__ import annotations
 import os, platform, shutil, subprocess, sys, threading, time
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Callable
 
 from ..llm.suggest import request_suggestions, Suggestion
 from ..util.shellparse import extract_commands, which_map
@@ -63,34 +63,37 @@ def is_installer_command(cmd: str) -> bool:
     return bool(bins and bins[0] in INSTALLERS)
 
 # ───── suggestions / ranking ─────
-def fetch_suggestions(model: str, query: str, n: int, ctx: dict, num_ctx: int, spinner=True) -> List[Suggestion]:
+def fetch_suggestions(model: str, query: str, n: int, ctx: dict, num_ctx: int, system_prompt: str, spinner=True) -> List[Suggestion]:
     if spinner:
-        return with_spinner(request_suggestions, "processing", model, query, n, ctx, num_ctx)
-    return request_suggestions(model, query, n, ctx, num_ctx)
+        return with_spinner(request_suggestions, "processing", model, query, n, ctx, num_ctx, system_prompt)
+    return request_suggestions(model, query, n, ctx, num_ctx, system_prompt)
+
+def stream_suggestions(model: str, query: str, n: int, ctx: dict, num_ctx: int,
+                       system_prompt: str, callback: Callable[[Suggestion], None],
+                       spinner: bool = True) -> List[Suggestion]:
+    collected: List[Suggestion] = []
+    for i in range(max(0, n)):
+        batch = fetch_suggestions(model, query, 1, ctx, num_ctx, system_prompt, spinner and i == 0)
+        if not batch:
+            break
+        s = batch[0]
+        setattr(s, "_is_new", True)
+        collected.append(s)
+        try:
+            callback(s)
+        except Exception:
+            pass
+    return collected
 
 def annotate_requires(s: Suggestion) -> Tuple[List[str], int, int]:
     req = s.requires or {}
     missing = [b for b, p in req.items() if not p]
     return missing, len(missing), len(s.command)
 
-def rank_only(items: List[Suggestion]) -> List[Suggestion]:
-    keyed = []
-    for s in items:
-        missing, mc, clen = annotate_requires(s)
-        setattr(s, "_missing_count", mc)
-        setattr(s, "_cmd_len", clen)
-        keyed.append((mc, clen, s))
-    keyed.sort(key=lambda t: (t[0], t[1]))
-    return [s for _,__,s in keyed]
-
-def mark_new(items: List[Suggestion]):
-    for s in items: setattr(s, "_is_new", True)
-
-def prepend_sorted(new_items: List[Suggestion], old_items: List[Suggestion]) -> List[Suggestion]:
-    """Sort only the new items, mark them new, and prepend to old."""
-    new_sorted = rank_only(new_items)
-    mark_new(new_sorted)
-    return new_sorted + old_items
+def append_new(old_items: List[Suggestion], new_items: List[Suggestion]) -> List[Suggestion]:
+    for s in new_items:
+        setattr(s, "_is_new", True)
+    return old_items + new_items
 
 # ───── rows for table ─────
 def build_rows(suggestions: List[Suggestion], show_explain: bool):
@@ -118,10 +121,9 @@ def make_style_functions(new_flags: List[bool]):
     import curses
     def style_cell(row, col, text):
         if col == 0:  # command
-            attr = curses.color_pair(2)
             if 0 <= row < len(new_flags) and new_flags[row]:
-                attr |= curses.A_BOLD
-            return attr
+                return curses.color_pair(6) | curses.A_BOLD
+            return curses.color_pair(2)
         if col == 1:  # status
             t = (text or "")
             if t.strip().startswith("✓"):

--- a/shai/cli.py
+++ b/shai/cli.py
@@ -233,7 +233,9 @@ def main(argv: List[str] | None = None) -> int:
                 followup=note,
             )
             new_sugs = stream_suggestions(model, query, num, ctx, num_ctx, system_prompt, None, cfg.spinner)
-            suggestions = append_new(suggestions, new_sugs)
+            for s in new_sugs:
+                setattr(s, "_is_new", True)
+            suggestions = new_sugs
             rows, misslists, new_flags = build_rows(suggestions, show_explain)
             header = line(f"Suggestions (Modified from {shorten(chosen.command)})")
             continue
@@ -249,7 +251,7 @@ def main(argv: List[str] | None = None) -> int:
             new_sugs = stream_suggestions(model, query, num, ctx, num_ctx, system_prompt, None, cfg.spinner)
             for s in new_sugs:
                 setattr(s, "_is_new", True)
-            suggestions = suggestions[:row_idx] + new_sugs + suggestions[row_idx+1:]
+            suggestions = new_sugs
             rows, misslists, new_flags = build_rows(suggestions, show_explain)
             header = line(f"Suggestions (Modified from {shorten(chosen.command)})")
             continue

--- a/shai/cli.py
+++ b/shai/cli.py
@@ -62,13 +62,17 @@ def append_shell_history(cmd: str) -> None:
 def center_input(prompt: str) -> str:
     os.system("clear")
     rows, cols = shutil.get_terminal_size((80,20))
-    print("\n" * max(0, rows//2 -1), end="")
+    print("\n" * max(0, rows//2 -1), end="", flush=True)
     print(prompt.center(cols))
     pad = cols // 2
     try:
         return input(" " * pad)
     except KeyboardInterrupt:
         return ""
+
+def ask_followup() -> str:
+    """Centered prompt for follow-up commands."""
+    return center_input("What do you want to do next?").strip()
 
 DANGEROUS_CMDS = {"rm", "dd", "mkfs", "shutdown", "reboot"}
 
@@ -190,7 +194,7 @@ def main(argv: List[str] | None = None) -> int:
                         header = line("Suggestions")
                         break
                     return rc
-                follow = center_input("What do you want to do next?").strip()
+                follow = ask_followup()
                 ctx = gather_context(
                     cfg,
                     recent_output=out,

--- a/shai/cli.py
+++ b/shai/cli.py
@@ -1,7 +1,7 @@
 # shai/cli.py
 from __future__ import annotations
-import argparse
-from typing import List, Any
+import argparse, os, shutil
+from typing import List
 
 import readline
 from .config import load_settings, add_ignored, get_ignored
@@ -10,17 +10,24 @@ from .pm.install_ui import offer_installs_for_missing
 from .app.flow import (
     gather_context, build_rows, make_style_functions,
     is_installer_command, run_and_capture, refresh_requires,
-    stream_suggestions,
+    stream_suggestions, append_new,
 )
 from .llm.suggest import ensure_ollama_running, explain_parts
 
+HISTFILE = os.path.expanduser("~/.shai_history")
+try:
+    readline.read_history_file(HISTFILE)
+except Exception:
+    pass
 
-def line(text: str, width: int = 60) -> None:
-    """Print a centered dashed line with text."""
+
+def line(text: str) -> str:
+    """Return a centered dashed line with text spanning the terminal width."""
+    width = shutil.get_terminal_size((80, 20)).columns
     pad = max(0, width - len(text) - 2)
     left = pad // 2
     right = pad - left
-    print("-" * left + f" {text} " + "-" * right)
+    return "-" * left + f" {text} " + "-" * right
 
 def prompt_edit(cmd: str) -> str:
     """Pre-fill input with command and allow user to edit before execution."""
@@ -37,6 +44,10 @@ def prompt_edit(cmd: str) -> str:
     if not new.strip():
         new = cmd
     readline.add_history(new)
+    try:
+        readline.write_history_file(HISTFILE)
+    except Exception:
+        pass
     return new
 
 def shorten(cmd: str, length: int = 40) -> str:
@@ -76,18 +87,9 @@ def main(argv: List[str] | None = None) -> int:
 
     ctx = gather_context(cfg, previous_query=query)
 
-    def fetch(n: int, context: dict):
-        sugs = stream_suggestions(model, query, n, context, num_ctx, cfg.system_prompt, None, cfg.spinner)
-        rows, miss, flags = build_rows(sugs, show_explain)
-        if show_explain:
-            rows.append(("[ Back (Esc) ]", "", "return"))
-        else:
-            rows.append(("[ Back (Esc) ]", ""))
-        miss.append([]); flags.append(False)
-        return sugs, rows, miss, flags
-
-    suggestions, rows, misslists, new_flags = fetch(num, ctx)
-    header = " Suggestions "
+    suggestions = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, None, cfg.spinner)
+    rows, misslists, new_flags = build_rows(suggestions, show_explain)
+    header = line("Suggestions")
 
     while True:
         if show_explain:
@@ -104,7 +106,7 @@ def main(argv: List[str] | None = None) -> int:
         style_cell, style_line = make_style_functions(new_flags)
 
         def menu_for_row(i: int):
-            return ["Execute", "Comment", "Exec → Continue", "Explain", "Variations"]
+            return ["Execute", "Comment", "Exec → Continue", "Explain", "Variations", "Back"]
 
         action, row_idx, sub_idx = grid_select(
             rows, colspecs,
@@ -116,9 +118,6 @@ def main(argv: List[str] | None = None) -> int:
         )
 
         if action in ("quit",) or row_idx is None:
-            print("\x1b[2mDone.\x1b[0m"); return 0
-
-        if row_idx == len(suggestions):
             print("\x1b[2mDone.\x1b[0m"); return 0
 
         chosen = suggestions[row_idx]
@@ -144,10 +143,12 @@ def main(argv: List[str] | None = None) -> int:
                 if sub_idx == 0:
                     if is_installer_command(cmd_to_run):
                         ctx = gather_context(cfg, previous_query=query)
-                        suggestions, rows, misslists, new_flags = fetch(len(suggestions), ctx)
+                        suggestions = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, None, cfg.spinner)
+                        rows, misslists, new_flags = build_rows(suggestions, show_explain)
+                        header = line("Suggestions")
                         break
                     return rc
-                line("Next")
+                print(line("Next"))
                 try:
                     follow = input("What do you want to do next? ").strip()
                 except KeyboardInterrupt:
@@ -159,41 +160,45 @@ def main(argv: List[str] | None = None) -> int:
                     last_executed=cmd_to_run,
                     followup=follow,
                 )
-                suggestions, rows, misslists, new_flags = fetch(len(suggestions), ctx)
-                header = f" Suggestions (Follow up to {shorten(cmd_to_run)}) "
+                new_sugs = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, None, cfg.spinner)
+                suggestions = append_new(suggestions, new_sugs)
+                rows, misslists, new_flags = build_rows(suggestions, show_explain)
+                header = line(f"Suggestions (Follow up to {shorten(cmd_to_run)})")
                 break
             continue
 
         # Explain
         if action == "submenu-selected" and sub_idx == 3:
-            line("Explain")
-            print("Command: " + chosen.command)
             parts = explain_parts(model, chosen.command, num_ctx)
+            rows_exp: List[List[str]] = []
+            rows_exp.append(("Command", chosen.command))
+            if getattr(chosen, "explanation_min", ""):
+                rows_exp.append(("Summary", chosen.explanation_min))
             if parts:
-                for idx, (p, d) in enumerate(parts):
-                    if idx == 0:
-                        print(f"- {p}: {d}")
-                    else:
-                        print(f"  - {p}: {d}")
+                for p, d in parts:
+                    rows_exp.append((p, d))
             elif getattr(chosen, "explanation_min", ""):
                 toks = chosen.command.split()
                 if toks:
-                    print(f"- {toks[0]}")
+                    rows_exp.append((toks[0], ""))
                     for t in toks[1:]:
-                        print(f"  - {t}")
+                        rows_exp.append((t, ""))
                 for p in [p.strip() for p in chosen.explanation_min.split(';') if p.strip()]:
-                    print("  - " + p)
-            else:
-                print("\x1b[2m(no explanation provided by the model)\x1b[0m")
-            line("Tools")
-            for b, p in (chosen.requires or {}).items():
-                print(f"  {b:10} {'✓ '+p if p else '✗ missing'}")
-            input("\x1b[2m\nPress Enter to return…\x1b[0m")
+                    rows_exp.append((p, ""))
+            if chosen.requires:
+                for b, pth in (chosen.requires or {}).items():
+                    rows_exp.append((b, ("✓ "+pth) if pth else "✗ missing"))
+            rows_exp.append(("[ Back (Esc) ]", ""))
+            colspecs_exp = [
+                ColSpec(header="Part", min_width=20, wrap=False, ellipsis=True),
+                ColSpec(header="Explanation", min_width=40, wrap=True),
+            ]
+            grid_select(rows_exp, colspecs_exp, title=line("Explain"))
             continue
 
         # Comment
         if action == "submenu-selected" and sub_idx == 1:
-            line("Comment")
+            print(line("Comment"))
             print("Command: " + chosen.command)
             if getattr(chosen, "explanation_min", ""):
                 print("Explanation:")
@@ -208,8 +213,10 @@ def main(argv: List[str] | None = None) -> int:
                 last_suggested=chosen.command,
                 followup=note,
             )
-            suggestions, rows, misslists, new_flags = fetch(len(suggestions), ctx)
-            header = f" Suggestions (Modified from {shorten(chosen.command)}) "
+            new_sugs = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, None, cfg.spinner)
+            suggestions = append_new(suggestions, new_sugs)
+            rows, misslists, new_flags = build_rows(suggestions, show_explain)
+            header = line(f"Suggestions (Modified from {shorten(chosen.command)})")
             continue
 
         # Variations
@@ -220,8 +227,13 @@ def main(argv: List[str] | None = None) -> int:
                 last_suggested=chosen.command,
                 followup="variants",
             )
-            suggestions, rows, misslists, new_flags = fetch(len(suggestions), ctx)
-            header = f" Suggestions (Modified from {shorten(chosen.command)}) "
+            new_sugs = stream_suggestions(model, query, num, ctx, num_ctx, cfg.system_prompt, None, cfg.spinner)
+            suggestions = append_new(suggestions, new_sugs)
+            rows, misslists, new_flags = build_rows(suggestions, show_explain)
+            header = line(f"Suggestions (Modified from {shorten(chosen.command)})")
+            continue
+
+        if action == "submenu-selected" and sub_idx == 5:
             continue
 
         if action == "row-selected":

--- a/shai/config.py
+++ b/shai/config.py
@@ -65,6 +65,7 @@ spinner = true
 [context]
 history_lines = 30
 use_stdin = true
+cwd_items_max = 40
 
 [pm]
 order = "pacman,apt,dnf,zypper,brew,flatpak,snap,yay,paru"
@@ -83,6 +84,7 @@ class Settings:
     submenu_cols: int = 3
     history_lines: int = 30
     use_stdin: bool = True
+    cwd_items_max: int = 40
     pm_order: list[str] | None = None
     system_prompt: str = DEFAULT_PROMPT
     ignored_bins: list[str] | None = None
@@ -155,6 +157,8 @@ def load_settings() -> Settings:
     try: s.history_lines = int(cx.get("history_lines", s.history_lines))
     except Exception: pass
     s.use_stdin = bool(cx.get("use_stdin", s.use_stdin))
+    try: s.cwd_items_max = int(cx.get("cwd_items_max", s.cwd_items_max))
+    except Exception: pass
 
     pm = d.get("pm", {})
     order = pm.get("order", "")

--- a/shai/llm/suggest.py
+++ b/shai/llm/suggest.py
@@ -111,13 +111,8 @@ def request_suggestions(model: str, query: str, n: int, context: Dict[str,Any], 
     return out
 
 
-def explain_parts(model: str, command: str, num_ctx: int) -> List[tuple[str, str]]:
+def explain_parts(model: str, command: str, num_ctx: int, prompt: str) -> List[tuple[str, str]]:
     """Break a shell command into components and explain each."""
-    prompt = (
-        "You are a Linux CLI assistant.\n"
-        "Given a shell command, break it into the executable and each flag or arg.\n"
-        "Return STRICT JSON: {\"parts\":[{\"text\":\"ls\",\"desc\":\"list directory contents\"}]}"
-    )
     messages = [
         {"role": "system", "content": prompt},
         {"role": "user", "content": command},

--- a/shai/llm/suggest.py
+++ b/shai/llm/suggest.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any
 import json, os
 
 from ..util.shellparse import extract_commands, which_map
+import urllib.request
 
 try:
     import ollama as pyollama
@@ -13,25 +14,41 @@ except Exception:
 
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
 
+def is_ollama_running(host: str = OLLAMA_HOST) -> bool:
+    try:
+        if HAS_OLLAMA:
+            pyollama.list()
+            return True
+        urllib.request.urlopen(host + "/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+def ensure_ollama_running():
+    if not is_ollama_running():
+        raise RuntimeError(
+            f"Ollama is not running at {OLLAMA_HOST}.\n"
+            "Start it with 'ollama serve' or see https://ollama.ai for installation instructions."
+        )
+
 @dataclass
 class Suggestion:
     command: str
     explanation_min: str = ""
     requires: Dict[str, str] | None = None
 
-SYSTEM_PROMPT = """You are a Linux CLI assistant.
-Return STRICT JSON:
-
-{"suggestions":[
-  {"command":"...", "explanation_min":"..."},
-  {"command":"...", "explanation_min":"..."}
-]}
-
-Rules:
-- Exactly N suggestions (provided in the user's JSON).
-- Single-line commands. Prefer safe flags (--dry-run, -n) where possible.
-- Prefer tools detected in context; if uncommon tool is useful, still use it.
-"""
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a Linux CLI assistant.\n"
+    "Return STRICT JSON:\n\n"
+    "{\"suggestions\":[\n"
+    "  {\"command\":\"...\", \"explanation_min\":\"...\"},\n"
+    "  {\"command\":\"...\", \"explanation_min\":\"...\"}\n"
+    "]}\n\n"
+    "Rules:\n"
+    "- Exactly N suggestions (provided in the user's JSON).\n"
+    "- Single-line commands. Prefer safe flags (--dry-run, -n) where possible.\n"
+    "- Prefer tools detected in context; if uncommon tool is useful, still use it."
+)
 
 def _chat(model: str, messages: list, num_ctx: int, force_json: bool = True) -> str:
     options = {"num_ctx": int(num_ctx)}
@@ -59,9 +76,10 @@ def _strip_code_fences(s: str) -> str:
             return s[1].split("\n", 1)[-1] if s[1].startswith(("bash","sh")) else s[1]
     return s
 
-def request_suggestions(model: str, query: str, n: int, context: Dict[str,Any], num_ctx: int) -> List[Suggestion]:
+def request_suggestions(model: str, query: str, n: int, context: Dict[str,Any], num_ctx: int,
+                        system_prompt: str = DEFAULT_SYSTEM_PROMPT) -> List[Suggestion]:
     user_payload = {"N": n, "USER_QUERY": query, "CONTEXT": context}
-    messages = [{"role":"system","content": SYSTEM_PROMPT},
+    messages = [{"role":"system","content": system_prompt},
                 {"role":"user","content": json.dumps(user_payload, ensure_ascii=False)}]
     raw = _chat(model, messages, num_ctx, True)
 
@@ -91,3 +109,28 @@ def request_suggestions(model: str, query: str, n: int, context: Dict[str,Any], 
         sug.requires = which_map(extract_commands(l))
         out.append(sug)
     return out
+
+
+def explain_parts(model: str, command: str, num_ctx: int) -> List[tuple[str, str]]:
+    """Break a shell command into components and explain each."""
+    prompt = (
+        "You are a Linux CLI assistant.\n"
+        "Given a shell command, break it into the executable and each flag or arg.\n"
+        "Return STRICT JSON: {\"parts\":[{\"text\":\"ls\",\"desc\":\"list directory contents\"}]}"
+    )
+    messages = [
+        {"role": "system", "content": prompt},
+        {"role": "user", "content": command},
+    ]
+    raw = _chat(model, messages, num_ctx, True)
+    try:
+        data = json.loads(raw)
+        parts = []
+        for p in data.get("parts", []):
+            text = (p or {}).get("text", "").strip()
+            if not text:
+                continue
+            parts.append((text, (p or {}).get("desc", "").strip()))
+        return parts
+    except Exception:
+        return []

--- a/shai/pm/install_ui.py
+++ b/shai/pm/install_ui.py
@@ -1,10 +1,18 @@
 # shai/pm/install_ui.py
 from __future__ import annotations
-import subprocess
+import subprocess, shutil
 from typing import List, Tuple, Callable, Optional
 
 from ..context.packages import available_pms, search_best_provider, install_command
 from ..ui.table import ColSpec, grid_select
+
+
+def line(text: str) -> str:
+    width = shutil.get_terminal_size((80, 20)).columns
+    pad = max(0, width - len(text) - 2)
+    left = pad // 2
+    right = pad - left
+    return "-" * left + f" {text} " + "-" * right
 
 def _run_stream(cmd: str) -> int:
     """Run install command interactively, streaming output and allowing user input."""
@@ -55,12 +63,12 @@ def offer_installs_for_missing(
             rows.append(("[ Add to exception list ]", f"ignore '{binary}' next time"))
             for pkg, desc in results[:max_pkgs]:
                 rows.append((install_command(pm_used, pkg), desc or ""))
-            title = f" Search: {search_cmd}  [via {pm_used}] "
+            title = line(f"Search: {search_cmd} [via {pm_used}]")
         else:
             rows.append(("[ Back (Esc) ]", "return to suggestions"))
             rows.append(("[ Continue ]", f"run without installing '{binary}'"))
             rows.append(("[ Add to exception list ]", f"ignore '{binary}' next time"))
-            title = f" No results for: {binary} "
+            title = line(f"No results for: {binary}")
 
         colspecs = [
             ColSpec("Install Command", min_width=36, wrap=False, ellipsis=True),

--- a/shai/ui/table.py
+++ b/shai/ui/table.py
@@ -213,6 +213,10 @@ def grid_select(
 ) -> Tuple[str, Optional[int], Optional[int]]:
     def inner(stdscr):
         curses.curs_set(0); curses.use_default_colors(); stdscr.timeout(100)
+        try:
+            curses.putp(curses.tigetstr("rmcup") or "")
+        except Exception:
+            pass
         # color pairs: 1=highlight bg, 2=cyan, 3=green, 4=red, 5=dim (fallback), 6=magenta
         try:
             curses.init_pair(1, curses.COLOR_BLACK, curses.COLOR_CYAN)
@@ -221,6 +225,7 @@ def grid_select(
             curses.init_pair(4, curses.COLOR_RED, -1)
             curses.init_pair(5, curses.COLOR_BLACK, -1)
             curses.init_pair(6, curses.COLOR_MAGENTA, -1)
+            curses.init_pair(7, curses.COLOR_YELLOW, -1)
         except Exception:
             pass
         HIL = curses.color_pair(1) | curses.A_BOLD

--- a/shai/ui/table.py
+++ b/shai/ui/table.py
@@ -212,14 +212,15 @@ def grid_select(
     line_style_fn: Optional[Callable[[int,int,int,str], int]] = None,
 ) -> Tuple[str, Optional[int], Optional[int]]:
     def inner(stdscr):
-        curses.curs_set(0); curses.use_default_colors()
-        # color pairs: 1=highlight bg, 2=cyan, 3=green, 4=red, 5=dim (fallback)
+        curses.curs_set(0); curses.use_default_colors(); stdscr.timeout(100)
+        # color pairs: 1=highlight bg, 2=cyan, 3=green, 4=red, 5=dim (fallback), 6=magenta
         try:
             curses.init_pair(1, curses.COLOR_BLACK, curses.COLOR_CYAN)
             curses.init_pair(2, curses.COLOR_CYAN, -1)
             curses.init_pair(3, curses.COLOR_GREEN, -1)
             curses.init_pair(4, curses.COLOR_RED, -1)
             curses.init_pair(5, curses.COLOR_BLACK, -1)
+            curses.init_pair(6, curses.COLOR_MAGENTA, -1)
         except Exception:
             pass
         HIL = curses.color_pair(1) | curses.A_BOLD
@@ -266,6 +267,8 @@ def grid_select(
             stdscr.refresh()
 
             ch = stdscr.getch()
+            if ch == -1:
+                continue
             if mode == "rows":
                 if ch in (curses.KEY_UP, ord('k')):   sel_row = max(0, sel_row-1)
                 elif ch in (curses.KEY_DOWN, ord('j')): sel_row = min(len(rows)-1, sel_row+1)

--- a/shai/util/shellparse.py
+++ b/shai/util/shellparse.py
@@ -1,15 +1,25 @@
 import re, shutil
 from typing import List, Dict
 
+# Bash built-ins and shell keywords that shouldn't be treated as external commands
+BUILTINS = {
+    "cd", "source", ".", "alias", "export", "unset", "set", "exit",
+    "echo", "readonly", "type", "hash", "bg", "fg"
+}
+
 def extract_commands(cmd: str) -> List[str]:
     parts = re.split(r'[|;&]', cmd)
     cmds, seen = [], set()
     for p in parts:
         toks = p.strip().split()
-        if not toks: continue
+        if not toks:
+            continue
         first = toks[1] if toks[0] == "sudo" and len(toks) > 1 else toks[0]
+        if first in BUILTINS:
+            continue
         if first not in seen:
-            seen.add(first); cmds.append(first)
+            seen.add(first)
+            cmds.append(first)
     return cmds
 
 def which_map(binaries: List[str]) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- Stream suggestions directly into the selection table and highlight new variants
- Added dashed-line separators and per-part command explanations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bf2a0324832fb9b3506132192e43